### PR TITLE
Fix compatibility with redmine 3.0 and later rails versions

### DIFF
--- a/app/controllers/bugherd_controller.rb
+++ b/app/controllers/bugherd_controller.rb
@@ -37,7 +37,7 @@ class BugherdController < ApplicationController
       return
     end
     list = []
-    Project.all(:order => 'name').each do |project|
+    Project.order(:name).each do |project|
       list << {:id => project.id, :name => project_name(project)} if project.active?
     end
     render :xml => list.to_xml(:root => 'records')
@@ -83,10 +83,10 @@ class BugherdController < ApplicationController
     @issue.subject = truncate(params[:description], 80) if params[:description]
     @issue.description = params[:description] if params[:description]
     
-    redmine_status = IssueStatus.first(:conditions => ['lower(name) = ?', params[:status].downcase]) if params[:status]
+    redmine_status = IssueStatus.where("lower(name) = ?", params[:status].downcase).first if params[:status]
     @issue.status = redmine_status if redmine_status
     
-    redmine_priority = IssuePriority.first(:conditions => ['lower(name) = ?', params[:priority].downcase]) if params[:priority]
+    redmine_priority = IssuePriority.where("lower(name) = ?", params[:priority].downcase).first if params[:priority]
     @issue.priority = redmine_priority if redmine_priority
     
     @issue.assigned_to = User.find_by_mail(params[:assignee]) if params[:assignee]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,13 @@
 if Rails::VERSION::MAJOR >= 3
 
 RedmineApp::Application.routes.draw do
-  match 'bugherd/plugin_version', :controller => 'bugherd', :action => 'plugin_version'
-  match 'bugherd/project_list.:format', :controller => 'bugherd', :action => 'project_list'
-  match 'bugherd/status_list.:format', :controller => 'bugherd', :action => 'status_list'
-  match 'bugherd/priority_list.:format', :controller => 'bugherd', :action => 'priority_list'
-  match 'bugherd/trigger_web_hook/:project_id.:format', :controller => 'bugherd', :action => 'trigger_web_hook'
-  match 'bugherd/issue/update.:format', :controller => 'bugherd', :action => 'update'
-  match 'bugherd/issue/add_comment.:format', :controller => 'bugherd', :action => 'add_comment'  
+  get 'bugherd/plugin_version', :controller => 'bugherd', :action => 'plugin_version'
+  get 'bugherd/project_list.:format', :controller => 'bugherd', :action => 'project_list'
+  get 'bugherd/status_list.:format', :controller => 'bugherd', :action => 'status_list'
+  get 'bugherd/priority_list.:format', :controller => 'bugherd', :action => 'priority_list'
+  get 'bugherd/trigger_web_hook/:project_id.:format', :controller => 'bugherd', :action => 'trigger_web_hook'
+  get 'bugherd/issue/update.:format', :controller => 'bugherd', :action => 'update'
+  get 'bugherd/issue/add_comment.:format', :controller => 'bugherd', :action => 'add_comment'
 end
 
 else


### PR DESCRIPTION
I've got no prior redmine or ruby rails experience but these patches got things working with The latest stable version of redmine and rails 4.2.1 (what's installed in ubuntu 14.04). Don't really have time to see if they are backwards compatible but would be nice to see them merged upstream if they don't break it too bad in earlier versions.

Environment:
  Redmine version                3.0.3.stable
  Ruby version                   1.9.3-p484 (2013-11-22) [x86_64-linux]
  Rails version                  4.2.1
  Environment                    production
  Database adapter               Mysql2
SCM:
  Subversion                     1.8.8
  Git                            1.9.1
  Filesystem                     
Redmine plugins:
  redmine_bugherd                2.0.1